### PR TITLE
High-level diagrams for decima's codebase

### DIFF
--- a/.codeboarding/Data Management.md
+++ b/.codeboarding/Data Management.md
@@ -1,0 +1,61 @@
+```mermaid
+graph LR
+    HDF5_Data_Loader["HDF5 Data Loader"]
+    Variant_Data_Processor["Variant Data Processor"]
+    Preprocessing_Utilities["Preprocessing Utilities"]
+    Attribution_Analysis_Module["Attribution Analysis Module"]
+    Variant_Data_Processor -- "specializes" --> HDF5_Data_Loader
+    Variant_Data_Processor -- "uses" --> Preprocessing_Utilities
+    Attribution_Analysis_Module -- "uses" --> HDF5_Data_Loader
+    Attribution_Analysis_Module -- "uses" --> Preprocessing_Utilities
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Data Management subsystem is responsible for the robust handling of biological sequence and gene expression data. It encompasses functionalities for reading and processing HDF5 files, managing genetic variant data, and preparing inputs for downstream analysis, including attribution studies. This subsystem ensures efficient data loading, augmentation, and transformation to support various computational biology tasks.
+
+### HDF5 Data Loader
+Manages the loading and initial processing of gene sequence and expression data from HDF5 files, including gene indexing, listing, and extraction of specific data points. It provides core utilities for data access and interacts with preprocessing utilities.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L74-L157" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.HDF5Dataset` (74:157)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L39-L41" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.get_gene_idx` (39:41)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L30-L36" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.list_genes` (30:36)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L50-L64" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.extract_gene_data` (50:64)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L44-L47" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5._extract_center` (44:47)</a>
+
+
+### Variant Data Processor
+Specializes in handling genetic variant data, including loading variant information, preparing mutated input sequences, and applying mutations for downstream analysis. It builds upon the HDF5 Data Loader for base data access.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L160-L249" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.VariantDataset` (160:249)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L67-L71" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.mutate` (67:71)</a>
+
+
+### Preprocessing Utilities
+Provides general utility functions for preparing and transforming raw data into a suitable format for model input, specifically including functions for creating inputs for variant analysis.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/preprocess.py#L268-L281" target="_blank" rel="noopener noreferrer">`decima.src.decima.preprocess.make_inputs` (268:281)</a>
+
+
+### Attribution Analysis Module
+Focuses on generating attributions by processing gene data, relying on the HDF5 Data Loader for data retrieval and Preprocessing Utilities for data preparation.
+
+
+**Related Classes/Methods**:
+
+- `decima.src.decima.interpret` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Evaluation and Visualization.md
+++ b/.codeboarding/Evaluation and Visualization.md
@@ -1,0 +1,40 @@
+```mermaid
+graph LR
+    Evaluation_Module["Evaluation Module"]
+    Visualization_Module["Visualization Module"]
+    Visualization_Module -- "depends on" --> Evaluation_Module
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Evaluation and Visualization component of `decima` is responsible for quantitatively assessing the model's performance, particularly in marker gene analysis, and for generating various plots and visual representations of these evaluation results. The main flow involves the Evaluation Module computing metrics and z-scores, which are then utilized by the Visualization Module to create insightful graphical summaries.
+
+### Evaluation Module
+This module provides core functionalities for quantitatively assessing model performance, particularly focusing on marker gene analysis. It includes functions for calculating and comparing marker z-scores, matching criteria for data filtering, and computing various marker-related metrics, preparing data for in-depth analysis and visualization.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/evaluate.py#L33-L37" target="_blank" rel="noopener noreferrer">`decima.src.decima.evaluate.compare_marker_zscores` (33:37)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/evaluate.py#L20-L30" target="_blank" rel="noopener noreferrer">`decima.src.decima.evaluate.marker_zscores` (20:30)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/evaluate.py#L8-L17" target="_blank" rel="noopener noreferrer">`decima.src.decima.evaluate.match_criteria` (8:17)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/evaluate.py#L40-L71" target="_blank" rel="noopener noreferrer">`decima.src.decima.evaluate.compute_marker_metrics` (40:71)</a>
+
+
+### Visualization Module
+This module is responsible for generating diverse graphical representations of the analyzed data, including marker box plots, gene and track scatter plots, and attribution peak visualizations. It leverages the evaluation results to provide insightful visual summaries of the model's performance and data characteristics.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L116-L201" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_marker_box` (116:201)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L9-L15" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_logo` (9:15)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L18-L62" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_gene_scatter` (18:62)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L65-L113" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_track_scatter` (65:113)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L204-L218" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_attribution_peaks` (204:218)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Model Core.md
+++ b/.codeboarding/Model Core.md
@@ -1,0 +1,80 @@
+```mermaid
+graph LR
+    Model_Core["Model Core"]
+    Training_and_Prediction_Orchestrator["Training and Prediction Orchestrator"]
+    Core_Predictive_Model["Core Predictive Model"]
+    Loss_Calculation_Module["Loss Calculation Module"]
+    Performance_Metrics_Module["Performance Metrics Module"]
+    Model_Core -- "comprises" --> Core_Predictive_Model
+    Model_Core -- "comprises" --> Loss_Calculation_Module
+    Model_Core -- "comprises" --> Performance_Metrics_Module
+    Training_and_Prediction_Orchestrator -- "initializes" --> Core_Predictive_Model
+    Training_and_Prediction_Orchestrator -- "invokes" --> Core_Predictive_Model
+    Training_and_Prediction_Orchestrator -- "initializes" --> Loss_Calculation_Module
+    Training_and_Prediction_Orchestrator -- "uses" --> Loss_Calculation_Module
+    Training_and_Prediction_Orchestrator -- "initializes" --> Performance_Metrics_Module
+    Training_and_Prediction_Orchestrator -- "updates" --> Performance_Metrics_Module
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This component overview describes the core computational elements and their orchestration within the Decima model. The Model Core encapsulates the fundamental neural network architecture, custom loss function, and disease-specific evaluation metrics, forming the computational backbone. The Training and Prediction Orchestrator acts as the central controller, initializing and managing the flow of data through the Core Predictive Model, applying the Loss Calculation Module, and evaluating performance using the Performance Metrics Module throughout the training, validation, and prediction phases.
+
+### Model Core
+Encapsulates the fundamental neural network architecture (DecimaModel), the custom loss function (TaskWisePoissonMultinomialLoss), and the disease-specific evaluation metric (DiseaseLfcMSE). It forms the computational backbone of the Decima model.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/decima_model.py#L11-L53" target="_blank" rel="noopener noreferrer">`decima.src.decima.decima_model.DecimaModel` (11:53)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/loss.py#L6-L41" target="_blank" rel="noopener noreferrer">`decima.src.decima.loss.TaskWisePoissonMultinomialLoss` (6:41)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/metrics.py#L6-L27" target="_blank" rel="noopener noreferrer">`decima.src.decima.metrics.DiseaseLfcMSE` (6:27)</a>
+
+
+### Training and Prediction Orchestrator
+This component serves as the primary controller for the entire machine learning pipeline. It initializes the core predictive model, the loss function, and performance metrics. It orchestrates the training, validation, and testing steps by managing data flow, invoking the forward pass of the predictive model, calculating loss, and updating metrics. It also handles prediction on new data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L38-L455" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel` (38:455)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L50-L88" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:__init__` (50:88)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L105-L126" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:forward` (105:126)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L128-L133" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:training_step` (128:133)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L135-L143" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:validation_step` (135:143)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L162-L173" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:test_step` (162:173)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L90-L103" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel.format_input` (90:103)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L223-L227" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel.reset_transform` (223:227)</a>
+
+
+### Core Predictive Model
+This component embodies the neural network architecture responsible for making predictions. It's a specialized BorzoiModel that takes one-hot encoded sequences as input and outputs raw predictions (logits) for various tasks. It can be initialized with pre-trained weights.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/decima_model.py#L11-L53" target="_blank" rel="noopener noreferrer">`decima.src.decima.decima_model.DecimaModel` (11:53)</a>
+
+
+### Loss Calculation Module
+This component provides the specific loss function used to train the predictive model. It calculates a combined Poisson and Multinomial negative log-likelihood loss, which is crucial for guiding the model's learning process by quantifying the discrepancy between its predictions and the true target values.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/loss.py#L6-L41" target="_blank" rel="noopener noreferrer">`decima.src.decima.loss.TaskWisePoissonMultinomialLoss` (6:41)</a>
+
+
+### Performance Metrics Module
+This component is responsible for computing specific evaluation metrics, such as the Mean Squared Error (MSE) on log-fold changes for disease-related tasks. It helps in assessing the model's performance beyond just the loss value, providing insights into its predictive accuracy on relevant biological outcomes.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/metrics.py#L6-L27" target="_blank" rel="noopener noreferrer">`decima.src.decima.metrics.DiseaseLfcMSE` (6:27)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Model Interpretation.md
+++ b/.codeboarding/Model Interpretation.md
@@ -1,0 +1,92 @@
+```mermaid
+graph LR
+    Attribution_Calculation["Attribution Calculation"]
+    Attribution_Peak_Analysis["Attribution Peak Analysis"]
+    Motif_Scanning["Motif Scanning"]
+    HDF5_Gene_Data_Extraction["HDF5 Gene Data Extraction"]
+    HDF5_Gene_Indexing_and_Listing["HDF5 Gene Indexing and Listing"]
+    HDF5_Dataset_Management["HDF5 Dataset Management"]
+    Variant_Dataset_Management["Variant Dataset Management"]
+    Attribution_Calculation -- "uses" --> HDF5_Gene_Data_Extraction
+    Attribution_Calculation -- "provides input to" --> Attribution_Peak_Analysis
+    Attribution_Calculation -- "provides input to" --> Motif_Scanning
+    Attribution_Peak_Analysis -- "provides input to" --> Motif_Scanning
+    HDF5_Gene_Data_Extraction -- "relies on" --> HDF5_Gene_Indexing_and_Listing
+    HDF5_Dataset_Management -- "uses" --> HDF5_Gene_Indexing_and_Listing
+    Variant_Dataset_Management -- "uses" --> HDF5_Gene_Indexing_and_Listing
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph outlines the components involved in model interpretation, specifically focusing on attribution analysis and data extraction from HDF5 files. The main flow involves extracting genomic data, calculating attributions using a trained model, and then analyzing these attributions to identify significant peaks and scan for motifs. The purpose is to provide insights into how the model makes predictions by highlighting important features in the genomic sequences.
+
+### Attribution Calculation
+This component is responsible for computing feature attributions for genomic sequences using a given model. It handles input data preparation, applies transformations to the model (e.g., specificity or aggregation), and performs the attribution calculation using methods like InputXGradient.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/interpret.py#L13-L53" target="_blank" rel="noopener noreferrer">`decima.src.decima.interpret.attributions` (13:53)</a>
+
+
+### Attribution Peak Analysis
+This component identifies significant peaks within the calculated attribution scores. It sorts these peaks by height and can relate them to the transcription start site (TSS) position.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/interpret.py#L56-L62" target="_blank" rel="noopener noreferrer">`decima.src.decima.interpret.find_attr_peaks` (56:62)</a>
+
+
+### Motif Scanning
+This component scans attribution scores and sequences for known motifs, providing a way to link high attribution regions to specific regulatory elements. It integrates with the attribution peaks to focus the scanning on relevant regions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/interpret.py#L65-L80" target="_blank" rel="noopener noreferrer">`decima.src.decima.interpret.scan_attributions` (65:80)</a>
+
+
+### HDF5 Gene Data Extraction
+This component provides functions to extract sequence and mask data for specific genes from HDF5 files. It can also merge sequence and mask data into a single tensor.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L50-L64" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.extract_gene_data` (50:64)</a>
+
+
+### HDF5 Gene Indexing and Listing
+This component provides utilities for counting, indexing, and listing genes stored within an HDF5 file, allowing for efficient access and management of genomic data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L12-L18" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.count_genes` (12:18)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L21-L27" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.index_genes` (21:27)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L30-L36" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.list_genes` (30:36)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L39-L41" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.get_gene_idx` (39:41)</a>
+
+
+### HDF5 Dataset Management
+This component provides a PyTorch Dataset implementation for loading and augmenting genomic sequence and label data from HDF5 files, suitable for training and prediction tasks.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L74-L157" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.HDF5Dataset` (74:157)</a>
+
+
+### Variant Dataset Management
+This component provides a PyTorch Dataset implementation specifically designed for handling genomic variant data from HDF5 files, including sequence augmentation and allele mutation for variant effect prediction.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L160-L249" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.VariantDataset` (160:249)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Training and Prediction Orchestrator.md
+++ b/.codeboarding/Training and Prediction Orchestrator.md
@@ -1,0 +1,70 @@
+```mermaid
+graph LR
+    LightningModel["LightningModel"]
+    DecimaModel["DecimaModel"]
+    LossFunction["LossFunction"]
+    Metrics["Metrics"]
+    LightningModel -- "initializes and utilizes" --> DecimaModel
+    LightningModel -- "uses for calculating loss" --> LossFunction
+    LightningModel -- "updates and computes" --> Metrics
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Training and Prediction Orchestrator, primarily embodied by the `LightningModel`, manages the entire machine learning lifecycle for the Decima model within the PyTorch Lightning framework. It orchestrates model initialization, data loading, forward passes, training, validation, testing, and prediction steps. The main flow involves initializing the `LightningModel` with model, training, and data parameters, which in turn initializes the `DecimaModel`, `LossFunction`, and `Metrics` components. During training, it utilizes data loaders to feed data to the `DecimaModel`, calculates loss using `LossFunction`, and updates `Metrics`. For prediction, it processes input data through the `DecimaModel` and applies any necessary transformations.
+
+### LightningModel
+The LightningModel acts as a wrapper for predictive sequence models, handling model initialization, loss function setup, metric tracking, and the overall training, validation, testing, and prediction workflows. It integrates with PyTorch Lightning for streamlined deep learning operations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L38-L455" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel` (38:455)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L50-L88" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:__init__` (50:88)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L105-L126" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:forward` (105:126)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L128-L133" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:training_step` (128:133)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L135-L143" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:validation_step` (135:143)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L162-L173" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:test_step` (162:173)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L278-L338" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:train_on_dataset` (278:338)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L358-L420" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:predict_on_dataset` (358:420)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L422-L455" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel:get_task_idxs` (422:455)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L90-L103" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel.format_input` (90:103)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L223-L227" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel.reset_transform` (223:227)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L198-L214" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel.parse_logger` (198:214)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L229-L243" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel.make_train_loader` (229:243)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L245-L259" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel.make_test_loader` (245:259)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L261-L276" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel.make_predict_loader` (261:276)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L340-L353" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel._get_dataset_attrs` (340:353)</a>
+
+
+### DecimaModel
+The DecimaModel represents the core predictive sequence model architecture. It is responsible for processing input sequences and generating raw predictions (logits) before activation and any further transformations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/decima_model.py#L11-L53" target="_blank" rel="noopener noreferrer">`decima.src.decima.decima_model.DecimaModel` (11:53)</a>
+
+
+### LossFunction
+The LossFunction component, specifically TaskWisePoissonMultinomialLoss, calculates the discrepancy between the model's predictions and the true labels. It is crucial for guiding the model's learning process during training and evaluation.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/loss.py#L6-L41" target="_blank" rel="noopener noreferrer">`decima.src.decima.loss.TaskWisePoissonMultinomialLoss` (6:41)</a>
+
+
+### Metrics
+The Metrics component, including DiseaseLfcMSE, is responsible for evaluating the performance of the model. It provides quantitative measures of how well the model is performing on various tasks.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/metrics.py#L6-L27" target="_blank" rel="noopener noreferrer">`decima.src.decima.metrics.DiseaseLfcMSE` (6:27)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,92 @@
+```mermaid
+graph LR
+    Model_Core["Model Core"]
+    Training_and_Prediction_Orchestrator["Training and Prediction Orchestrator"]
+    Data_Management["Data Management"]
+    Evaluation_and_Visualization["Evaluation and Visualization"]
+    Model_Interpretation["Model Interpretation"]
+    Training_and_Prediction_Orchestrator -- "initializes" --> Model_Core
+    Training_and_Prediction_Orchestrator -- "uses" --> Model_Core
+    Training_and_Prediction_Orchestrator -- "loads data from" --> Data_Management
+    Model_Interpretation -- "extracts data from" --> Data_Management
+    Model_Interpretation -- "interacts with" --> Model_Core
+    Evaluation_and_Visualization -- "receives predictions from" --> Training_and_Prediction_Orchestrator
+    click Model_Core href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/decima/Model Core.md" "Details"
+    click Training_and_Prediction_Orchestrator href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/decima/Training and Prediction Orchestrator.md" "Details"
+    click Data_Management href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/decima/Data Management.md" "Details"
+    click Evaluation_and_Visualization href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/decima/Evaluation and Visualization.md" "Details"
+    click Model_Interpretation href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/decima/Model Interpretation.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The `decima` project implements a neural network model for analyzing biological sequence and gene expression data. Its core functionality involves training a deep learning model, managing complex HDF5 datasets, and providing tools for model evaluation, visualization, and interpretation of predictions.
+
+### Model Core
+Encapsulates the fundamental neural network architecture (DecimaModel), the custom loss function (TaskWisePoissonMultinomialLoss), and the disease-specific evaluation metric (DiseaseLfcMSE). It forms the computational backbone of the Decima model.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/decima_model.py#L11-L53" target="_blank" rel="noopener noreferrer">`decima.src.decima.decima_model.DecimaModel` (11:53)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/loss.py#L6-L41" target="_blank" rel="noopener noreferrer">`decima.src.decima.loss.TaskWisePoissonMultinomialLoss` (6:41)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/metrics.py#L6-L27" target="_blank" rel="noopener noreferrer">`decima.src.decima.metrics.DiseaseLfcMSE` (6:27)</a>
+
+
+### Training and Prediction Orchestrator
+Integrates the Decima model with the PyTorch Lightning framework, managing the entire machine learning lifecycle including model initialization, forward passes, training, validation, testing, and prediction steps. It handles data loading and orchestrates the training and prediction processes.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/lightning.py#L38-L455" target="_blank" rel="noopener noreferrer">`decima.src.decima.lightning.LightningModel` (38:455)</a>
+
+
+### Data Management
+Responsible for reading, processing, and augmenting biological sequence and gene expression data stored in HDF5 files. It includes utilities for gene indexing, extracting specific data points, and defining dataset classes for efficient data loading during training and inference, including specific handling for variant data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L74-L157" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.HDF5Dataset` (74:157)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L160-L249" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.VariantDataset` (160:249)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L39-L41" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.get_gene_idx` (39:41)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L30-L36" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.list_genes` (30:36)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L50-L64" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.extract_gene_data` (50:64)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L44-L47" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5._extract_center` (44:47)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/read_hdf5.py#L67-L71" target="_blank" rel="noopener noreferrer">`decima.src.decima.read_hdf5.mutate` (67:71)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/preprocess.py#L268-L281" target="_blank" rel="noopener noreferrer">`decima.src.decima.preprocess.make_inputs` (268:281)</a>
+
+
+### Evaluation and Visualization
+Provides functionalities for quantitatively assessing the performance of the model, particularly focusing on marker gene analysis and criteria matching, and generates plots and visual representations of the model's evaluation results.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/evaluate.py#L33-L37" target="_blank" rel="noopener noreferrer">`decima.src.decima.evaluate.compare_marker_zscores` (33:37)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/evaluate.py#L20-L30" target="_blank" rel="noopener noreferrer">`decima.src.decima.evaluate.marker_zscores` (20:30)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/evaluate.py#L8-L17" target="_blank" rel="noopener noreferrer">`decima.src.decima.evaluate.match_criteria` (8:17)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/evaluate.py#L40-L71" target="_blank" rel="noopener noreferrer">`decima.src.decima.evaluate.compute_marker_metrics` (40:71)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L116-L201" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_marker_box` (116:201)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L9-L15" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_logo` (9:15)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L18-L62" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_gene_scatter` (18:62)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L65-L113" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_track_scatter` (65:113)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/visualize.py#L204-L218" target="_blank" rel="noopener noreferrer">`decima.src.decima.visualize.plot_attribution_peaks` (204:218)</a>
+
+
+### Model Interpretation
+Provides tools and methods for interpreting the predictions and internal workings of the model, such as attribution analysis to understand feature importance and motif scanning.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/interpret.py#L13-L53" target="_blank" rel="noopener noreferrer">`decima.src.decima.interpret.attributions` (13:53)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/interpret.py#L56-L62" target="_blank" rel="noopener noreferrer">`decima.src.decima.interpret.find_attr_peaks` (56:62)</a>
+- <a href="https://github.com/Genentech/decima/blob/master/src/decima/interpret.py#L65-L80" target="_blank" rel="noopener noreferrer">`decima.src.decima.interpret.scan_attributions` (65:80)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR contains high-level diagrams for the decima's codebase. You can see how they render in Github here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/decima/on_boarding.md

The idea of these diagrams are to help people get up-to-speed with the codebase. I know that a lot of scientists interact with these codebases and I suppose they can make use of such diagrams and grasp the idea much faster than reading the code itself. I would love to hear what do you think about Diagram first documentation for on-boarding and if it fits in your existing on-boarding processes.

Any feedback is more than welcome! We are also working on a github action so that the diagrams are always up-to-date with the codebase!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.