### PR TITLE
Fix EnsembleLightningModel VEP: run models independently to avoid allele/variant dimension scrambling

### DIFF
--- a/src/decima/model/lightning.py
+++ b/src/decima/model/lightning.py
@@ -549,23 +549,31 @@ class EnsembleLightningModel(LightningModel):
         compare_func: Optional[Union[str, Callable]] = None,
         float_precision: str = "32",
     ):
-        preds = super().predict_on_dataset(
-            dataset=dataset,
-            device=device,
-            num_workers=num_workers,
-            batch_size=batch_size,
-            augment_aggfunc=augment_aggfunc,
-            compare_func=compare_func,
-            float_precision=float_precision,
-        )
-        expression = rearrange(
-            preds["expression"],
-            "(e b) t -> e b t",
-            e=len(self.models),
-        )
+        # Run each constituent model independently so that allele ordering and
+        # variant ordering are handled correctly by LightningModel.predict_on_dataset.
+        # The previous approach (super().predict_on_dataset via a shared trainer) had
+        # two bugs:
+        # 1. With batch_size=1 the 4-model concat in predict_step scrambled the allele
+        #    dimension, computing cross-model differences instead of alt-ref LFC.
+        # 2. With n_seqs > 1 the subsequent "(e b) t -> e b t" rearrange treated model
+        #    index as the outer dimension, but the actual ordering coming out of the
+        #    shared trainer is variant-outer, mixing LFCs across models and genes.
+        all_preds = [
+            model.predict_on_dataset(
+                dataset=dataset,
+                device=device,
+                num_workers=num_workers,
+                batch_size=batch_size,
+                augment_aggfunc=augment_aggfunc,
+                compare_func=compare_func,
+                float_precision=float_precision,
+            )
+            for model in self.models
+        ]
+        expression = np.stack([p["expression"] for p in all_preds])  # (e, b, T)
         return {
-            "expression": expression.mean(axis=0),
-            "warnings": preds["warnings"],
+            "expression": expression.mean(axis=0),  # (b, T)
+            "warnings": all_preds[0]["warnings"],
             "ensemble_preds": expression,
         }
 

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -1,8 +1,9 @@
 import pytest
 import torch
+import numpy as np
 from decima.constants import DECIMA_CONTEXT_SIZE, MODEL_METADATA, DEFAULT_ENSEMBLE
 from decima.data.dataset import VariantDataset
-from decima.model.lightning import LightningModel, GeneMaskLightningModel
+from decima.model.lightning import LightningModel, EnsembleLightningModel, GeneMaskLightningModel
 from decima.model.metrics import WarningType
 
 from conftest import device
@@ -73,3 +74,48 @@ def test_GeneMaskLightningModel_forward():
     ).to(device)
     preds = model(seq)
     assert preds.shape == (1, metadata["num_tasks"], 1)
+
+
+def test_EnsembleLightningModel_predict_on_dataset_matches_individual_replicates():
+    """Ensemble mean must equal the mean of per-model predictions for any n_seqs.
+
+    Two bugs caused wrong results when n_seqs > 1:
+    - Bug 1 (batch_size=1): allele dimension scrambled by 4-model concat in predict_step.
+    - Bug 2 (n_seqs > 1): rearrange '(e b) -> e b' treated model as outer dim, but the
+      actual ordering from predict_step is variant-outer, so models and variants were mixed.
+
+    We mock predict_on_dataset on each constituent model to isolate and test the ensemble
+    averaging logic without running expensive forward passes.
+    """
+    from unittest.mock import patch, MagicMock
+
+    n_variants, n_tasks = 5, 10  # n_variants > 1 exercises the n_seqs > 1 bug
+    warnings = {"allele_mismatch_with_reference_genome": 0, "unknown": 0}
+
+    np.random.seed(0)
+    preds_m0 = np.random.randn(n_variants, n_tasks).astype(np.float32)
+    np.random.seed(1)
+    preds_m1 = np.random.randn(n_variants, n_tasks).astype(np.float32)
+
+    m0 = LightningModel(model_params={"n_tasks": n_tasks, "init_borzoi": False}, name="v1_rep0")
+    m1 = LightningModel(model_params={"n_tasks": n_tasks, "init_borzoi": False}, name="v1_rep1")
+    ensemble = EnsembleLightningModel([m0, m1])
+
+    sentinel_dataset = MagicMock()
+
+    with patch.object(m0, "predict_on_dataset", return_value={"expression": preds_m0, "warnings": warnings}) as mock0, \
+         patch.object(m1, "predict_on_dataset", return_value={"expression": preds_m1, "warnings": warnings}) as mock1:
+        result = ensemble.predict_on_dataset(sentinel_dataset, device="cpu", batch_size=4)
+
+    # Both constituent models must have been called with the forwarded arguments
+    mock0.assert_called_once_with(dataset=sentinel_dataset, device="cpu", num_workers=1, batch_size=4,
+                                  augment_aggfunc="mean", compare_func=None, float_precision="32")
+    mock1.assert_called_once_with(dataset=sentinel_dataset, device="cpu", num_workers=1, batch_size=4,
+                                  augment_aggfunc="mean", compare_func=None, float_precision="32")
+
+    expected_mean = (preds_m0 + preds_m1) / 2
+    np.testing.assert_allclose(result["expression"], expected_mean, rtol=1e-6)
+
+    # Per-replicate outputs must match the corresponding individual model predictions
+    np.testing.assert_allclose(result["ensemble_preds"][0], preds_m0, rtol=1e-6)
+    np.testing.assert_allclose(result["ensemble_preds"][1], preds_m1, rtol=1e-6)


### PR DESCRIPTION
## Problem

`predict_variant_effect` with `model='ensemble'` produced wrong log-fold-change predictions. The ensemble mean did not match the arithmetic mean of the four constituent replicate models run individually.

Confirmed by running rs2158799 (chr7:28237488 C>G) against JAZF1 in blood cell types:

| Approach | Classical monocyte median LFC |
|---|---|
| `model='ensemble'` (broken) | −0.043 |
| Each replicate individually, averaged | −0.268 (correct) |

## Root cause: two bugs in `EnsembleLightningModel.predict_on_dataset`

### Bug 1 — batch_size=1 allele scrambling

`EnsembleLightningModel.predict_step` concatenates the outputs of all 4 models along `dim=0` within each batch. With the default `batch_size=1`, ref and alt alleles land in **separate** batches. After model-concatenation the flattened tensor becomes:

```
[m0_ref, m1_ref, m2_ref, m3_ref,  m0_alt, m1_alt, m2_alt, m3_alt]
```

The subsequent `rearrange("(b n a) t -> b n a t", a=2)` in `LightningModel.predict_on_dataset` then groups `m0_ref` with `m1_ref` as the two "alleles" for a single variant, and the LFC `expression[:,:,1,:] - expression[:,:,0,:]` computes **cross-model differences** instead of alt−ref.

### Bug 2 — n_seqs > 1 model/variant dimension swap

With `batch_size=n_alleles=2` (which does pair alleles correctly), the LFC tensor after all batches are collected is ordered **variant-outer**:

```
[JAZF1_m0, JAZF1_m1, JAZF1_m2, JAZF1_m3,
 JAZF1-AS1_m0, JAZF1-AS1_m1, ...,
 CREB5_m0, ...]
```

`EnsembleLightningModel.predict_on_dataset` then applied `rearrange("(e b) t -> e b t", e=4)`, which assumed **model-outer** ordering. With `n_seqs=3` genes this sliced off the wrong blocks, mixing LFCs across genes and models. The ensemble mean and the `save_replicates` per-replicate columns were both wrong.

Bug 2 only manifests when a variant overlaps more than one gene (`n_seqs > 1`). Gene expression prediction (`n_alleles=1`) was not affected by either bug.

## Fix

Replace the `super().predict_on_dataset()` + broken rearrange with a loop that runs each constituent model's `predict_on_dataset` **independently**, then stacks and averages:

```python
all_preds = [model.predict_on_dataset(dataset, ...) for model in self.models]
expression = np.stack([p["expression"] for p in all_preds])  # (e, b, T)
return {"expression": expression.mean(axis=0), "ensemble_preds": expression, ...}
```

Each `LightningModel.predict_on_dataset` correctly handles allele ordering for any `batch_size` and any `n_seqs`. The explicit `np.stack` replaces the incorrect `(e b) t -> e b t` rearrange.

## Test

Added `test_EnsembleLightningModel_predict_on_dataset_matches_individual_replicates` to `tests/test_lightning.py`. The test mocks `predict_on_dataset` on each constituent model (so no GPU forward passes needed) and asserts:

1. The ensemble mean equals the arithmetic mean of the mocked per-model predictions.
2. `ensemble_preds[i]` matches model `i`'s predictions exactly.
3. Each constituent model was called with the correct forwarded arguments.

The test runs in ~5 seconds and does not require a long-running mark.

## Verification

```
45 passed, 0 failed (full test suite)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)